### PR TITLE
Remove {"maxNativeZoom": 17} for ort.

### DIFF
--- a/layers_txt/layers0.txt
+++ b/layers_txt/layers0.txt
@@ -57,7 +57,6 @@
       "subdomains": "",
       "attribution": "",
       "cocotile": true,
-      "maxNativeZoom": 17,
       "legendUrl": "http://maps.gsi.go.jp/development/ichiran.html#ort",
       "html": ""
     }


### PR DESCRIPTION
Remove {"maxNativeZoom": 17} for {"id": "ort"} because it is no longer necessary.
