### PR TITLE
マルチライン・マルチポイントの編集における不具合の修正

### DIFF
--- a/js/gsimaps.js
+++ b/js/gsimaps.js
@@ -42233,24 +42233,26 @@ GSI.SakuzuListItem = L.Evented.extend({
       }
     }
 
-    var iconUrl = options.icon.options.iconUrl;
-    var iconSize = options.icon.options.iconSize;
-    var iconAnchor = options.icon.options.iconAnchor;
-    var html = options.icon.options.html;
-    if (options.icon.options.className == 'gsi-div-icon') {
-      result.properties["_markerType"] = "DivIcon";
-      result.properties["_html"] = (html || html != '' ? html : '　');
-    }
-    else {
-      result.properties["_markerType"] = "Icon";
-      result.properties["_iconUrl"] = iconUrl;
-    }
-    result.properties["_iconSize"] = iconSize;
-    result.properties["_iconAnchor"] = iconAnchor;
+    if (typeof options.icon !== 'undefined') {
+      var iconUrl = options.icon.options.iconUrl;
+      var iconSize = options.icon.options.iconSize;
+      var iconAnchor = options.icon.options.iconAnchor;
+      var html = options.icon.options.html;
+      if (options.icon.options.className == 'gsi-div-icon') {
+        result.properties["_markerType"] = "DivIcon";
+        result.properties["_html"] = (html || html != '' ? html : '　');
+      }
+      else {
+        result.properties["_markerType"] = "Icon";
+        result.properties["_iconUrl"] = iconUrl;
+      }
+      result.properties["_iconSize"] = iconSize;
+      result.properties["_iconAnchor"] = iconAnchor;
 
-    if (!result.properties["_iconSize"]) delete result.properties["_iconSize"];
+      if (!result.properties["_iconSize"]) delete result.properties["_iconSize"];
 
-    if (!result.properties["_iconAnchor"]) delete result.properties["_iconAnchor"];
+      if (!result.properties["_iconAnchor"]) delete result.properties["_iconAnchor"];
+    }
 
     if (layer.feature && layer.feature.properties) {
       for (var key in layer.feature.properties) {

--- a/js/gsimaps.js
+++ b/js/gsimaps.js
@@ -40976,7 +40976,6 @@ GSI.SakuzuListItem = L.Evented.extend({
 
       case GSI.SakuzuListItem.FREEHAND:
       case GSI.SakuzuListItem.LINESTRING:
-      case GSI.SakuzuListItem.MULTILINESTRING:
       case GSI.SakuzuListItem.POLYGON:
 
         targetLayer.options.editing = {};

--- a/js/gsimaps.js
+++ b/js/gsimaps.js
@@ -39265,6 +39265,7 @@ GSI.SakuzuListItem = L.Evented.extend({
         break;
 
       case GSI.SakuzuListItem.LINESTRING:
+      case GSI.SakuzuListItem.MULTILINESTRING:
       case GSI.SakuzuListItem.FREEHAND:
         result = L.polyline(this._cloneLatLngs(layer.getLatLngs()), layer.options);
         result.feature = layer.feature;
@@ -39284,7 +39285,6 @@ GSI.SakuzuListItem = L.Evented.extend({
         result = L.circle(latlng, radius, layer.options);
         break;
 
-      case GSI.SakuzuListItem.MULTILINESTRING:
       case GSI.SakuzuListItem.MULTIPOINT:
         result = L.featureGroup();
         result.feature = layer.feature;
@@ -39361,6 +39361,9 @@ GSI.SakuzuListItem = L.Evented.extend({
             break;
           case "LineString":
             itemType = GSI.SakuzuListItem.LINESTRING;
+            break;
+          case "MultiLineString":
+            itemType = GSI.SakuzuListItem.MULTILINESTRING;
             break;
         }
       }
@@ -40973,6 +40976,7 @@ GSI.SakuzuListItem = L.Evented.extend({
 
       case GSI.SakuzuListItem.FREEHAND:
       case GSI.SakuzuListItem.LINESTRING:
+      case GSI.SakuzuListItem.MULTILINESTRING:
       case GSI.SakuzuListItem.POLYGON:
 
         targetLayer.options.editing = {};
@@ -40996,7 +41000,6 @@ GSI.SakuzuListItem = L.Evented.extend({
         break;
 
       case GSI.SakuzuListItem.MULTIPOINT:
-      case GSI.SakuzuListItem.MULTILINESTRING:
         var layers = targetLayer.getLayers();
         if (clearPathList) this._editingPathList = [];
         for (var i = 0; i < layers.length; i++) {

--- a/js/gsimaps.js
+++ b/js/gsimaps.js
@@ -42346,7 +42346,7 @@ GSI.SakuzuListItem.typeToTitle = function(drawType) {
       break;
 
     case GSI.SakuzuListItem.MULTIPOINT:
-      result = "複数マーカー（アイコン）";
+      result = "マーカー（アイコン）（マルチパート）";
       break;
 
     case GSI.SakuzuListItem.POINT_CIRCLE:
@@ -42358,8 +42358,11 @@ GSI.SakuzuListItem.typeToTitle = function(drawType) {
         break;
 
     case GSI.SakuzuListItem.LINESTRING:
-    case GSI.SakuzuListItem.MULTILINESTRING:
         result = "線";
+        break;
+
+    case GSI.SakuzuListItem.MULTILINESTRING:
+        result = "線（マルチパート）";
         break;
 
     case GSI.SakuzuListItem.POLYGON:
@@ -42375,7 +42378,7 @@ GSI.SakuzuListItem.typeToTitle = function(drawType) {
         break;
 
     case GSI.SakuzuListItem.MULTIPOLYGON:
-      result = "マルチポリゴン";
+      result = "ポリゴン（マルチパート）";
       break;
 
     default:


### PR DESCRIPTION
マルチライン・マルチポイントのGeoJSONを読み込まれたときに、編集する不具合を確認できました。

* マルチポイントの不具合原因は、通常ポイントと違ってiconの設定が存在しないため、期待する場所のicon設定を読み込まれないまま、エラーになりました。エラーハンドリングを強化し、期待した場所にiconが存在しないときに編集処理を続けるように修正しました。
* マルチラインの不具合原因は、マルチポイントと同様に `L.FeatureGroup` に複数のラインストリングが入っていることを期待したところ、 `L.MultiPolyline` として保存されました。マルチラインのハンドリングを `L.MultiPolyline` で動くように修正しました。

ご確認のほど、よろしくお願いいたします。