### PR TITLE
提案：「自分で作る色別標高図」にて、最高標高側がグラデーションに含まれるようにする。

### DIFF
--- a/globe/resource/gsiglobe.js
+++ b/globe/resource/gsiglobe.js
@@ -21698,8 +21698,10 @@ GSI.EditReliefDialog = GSI.Dialog.extend( {
         if ( tileList.length <= 0 ) {
           var colors = $.extend(true, [], GSI.ReliefTileLayer.getElevationSampleData().colors );
           var low = Math.floor( minMax.min );
-          if ( low < 0 ) low = 0;
-          var hi = Math.floor( minMax.max );
+          var hi = Math.ceil( minMax.max );
+          if (low < 0 && hi > 0){
+            low = 0;
+          }
           colors[ 0].h = low;
           for (var i = 1; i < colors.length - 2; i++) {
             var p = (1 / (colors.length - 1)) * (i);

--- a/js/gsimaps.js
+++ b/js/gsimaps.js
@@ -29742,7 +29742,7 @@ GSI.EditReliefDialog = GSI.Dialog.extend({
         if (tileList.length <= 0) {
           var colors = $.extend(true, [], GSI.ReliefTileLayer.getElevationSampleData().colors);
           var low = Math.floor(minMax.min);
-          var hi = Math.floor(minMax.max);
+          var hi = Math.ceil( minMax.max );
           if (low < 0 && hi > 0){
             low = 0;
           }


### PR DESCRIPTION
現状の自動色分けでは、描画範囲内の標高が 10.5m ~ 20.5m のとき、グラデーションの範囲が 10.0m ~ 20.0m で設定されます。
[gsimaps.js:29745](https://github.com/gsi-cyberjapan/gsimaps/blob/b2c2bf74c86e342b7b98d6eb6fd7d5f3bdca83b5/js/gsimaps.js#L29745) で最高標高側を floor しているのを代わりに ceil するようにして、上記例での範囲が 10.0m ~ 21.0m となるほうが便利であるように感じます。